### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -8,7 +8,7 @@ purchasing store for extensions and subscriptions for your app.
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
 started with using this module in your application.
 
 ## Accessing the Ti.Paypal Module


### PR DESCRIPTION
Replaced `../titanium﻿..` with `../platform﻿..` in any and all URLs of this yaml file.

https://jira.appcelerator.org/browse/MOD-2124